### PR TITLE
Add ctypes patch

### DIFF
--- a/packages/ctypes/ctypes.0.19.1+flambda2/files/fix-callback-lifetime-test.patch
+++ b/packages/ctypes/ctypes.0.19.1+flambda2/files/fix-callback-lifetime-test.patch
@@ -1,0 +1,39 @@
+commit c6604df9aa68ede640fc07459099ef953f4520e7
+Author: Jeremy Yallop <yallop@gmail.com>
+Date:   Thu Aug 26 08:55:29 2021 +0100
+
+    Use Sys.opaque_identity to prevent the optimiser moving code across GCs.
+
+diff --git a/tests/test-callback_lifetime/test_callback_lifetime.ml b/tests/test-callback_lifetime/test_callback_lifetime.ml
+index fdde0f1..1af4a99 100644
+--- a/tests/test-callback_lifetime/test_callback_lifetime.ml
++++ b/tests/test-callback_lifetime/test_callback_lifetime.ml
+@@ -106,22 +106,24 @@ struct
+     let closure x y = x * y in
+ 
+     (* First, the naive implementation.  This should fail, because arg is
+-       collected before ret is called. *)
+-    let ret = Naive.make ~arg:(closure (int_of_string "3")) in
++       collected before ret is called. Here and below, Sys.opaque_identity prevents the
++       optimizer from moving any part of the closure creation across the call to
++       Gc.full_major. *)
++    let ret = Sys.opaque_identity (Naive.make ~arg:(closure (int_of_string "3"))) in
+     Gc.full_major ();
+     assert_raises CallToExpiredClosure
+       (fun () -> Naive.get ret 5);
+ 
+     (* Now a more careful implementation.  This succeeds, because we keep a
+        reference to arg around with the reference to ret *)
+-    let ret = Better.make ~arg:(closure (int_of_string "3")) in
++    let ret = Sys.opaque_identity (Better.make ~arg:(closure (int_of_string "3"))) in
+     Gc.full_major ();
+     assert_equal 15 (Better.get ret 5);
+     let _ = Ctypes_memory_stubs.use_value ret in
+ 
+     (* However, even with the careful implementation things can go wrong if we
+        keep a reference to ret beyond the lifetime of the pair. *)
+-    let ret = Better.get (Better.make ~arg:(closure (int_of_string "3"))) in
++    let ret = Sys.opaque_identity (Better.get (Better.make ~arg:(closure (int_of_string "3")))) in
+     Gc.full_major ();
+     assert_raises CallToExpiredClosure
+       (fun () -> ret 5);

--- a/packages/ctypes/ctypes.0.19.1+flambda2/opam
+++ b/packages/ctypes/ctypes.0.19.1+flambda2/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+maintainer: "yallop@gmail.com"
+homepage: "https://github.com/ocamllabs/ocaml-ctypes"
+doc: "http://ocamllabs.github.io/ocaml-ctypes"
+dev-repo: "git+http://github.com/ocamllabs/ocaml-ctypes.git"
+bug-reports: "http://github.com/ocamllabs/ocaml-ctypes/issues"
+license: "MIT"
+build: [
+  [make "XEN=%{mirage-xen:enable}%" "libffi.config"]
+    {ctypes-foreign:installed}
+  ["touch" "libffi.config"] {!ctypes-foreign:installed}
+  [make "XEN=%{mirage-xen:enable}%" "ctypes-base" "ctypes-stubs"]
+  [make "XEN=%{mirage-xen:enable}%" "ctypes-foreign"]
+    {ctypes-foreign:installed}
+  [make "test"] {with-test}
+]
+install: [
+  [make "install" "XEN=%{mirage-xen:enable}%"]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "integers" { >= "0.3.0" }
+  "ocamlfind" {build}
+  "lwt" {with-test & >= "3.2.0"}
+  "ctypes-foreign" {with-test}
+  "ounit" {with-test}
+  "conf-ncurses" {with-test}
+  "bigarray-compat"
+]
+depopts: [
+  "ctypes-foreign"
+  "mirage-xen"
+]
+tags: ["org:ocamllabs" "org:mirage"]
+synopsis: "Combinators for binding to C libraries without writing any C"
+description: """
+ctypes is a library for binding to C libraries using pure OCaml. The primary
+aim is to make writing C extensions as straightforward as possible.
+
+The core of ctypes is a set of combinators for describing the structure of C
+types -- numeric types, arrays, pointers, structs, unions and functions. You
+can use these combinators to describe the types of the functions that you want
+to call, then bind directly to those functions -- all without writing or
+generating any C!
+
+To install the optional `ctypes.foreign` interface (which uses `libffi` to
+provide dynamic access to foreign libraries), you will need to also install
+the `ctypes-foreign` optional dependency:
+
+    opam install ctypes ctypes-foreign
+
+This will make the `ctypes.foreign` ocamlfind subpackage available."""
+authors: "yallop@gmail.com"
+url {
+  src: "https://github.com/ocamllabs/ocaml-ctypes/archive/0.19.1.tar.gz"
+  checksum: "md5=ceb891ec568fd7da76c31af270a2afe2"
+}
+conflicts: [
+  "mirage-xen" {>= "6.0.0"}
+]
+patches: ["fix-callback-lifetime-test.patch"]
+extra-files: [ ["fix-callback-lifetime-test.patch" "md5=82b4e84175d394722f885551c4f7c9ab"] ]


### PR DESCRIPTION
This cherry-picks https://github.com/ocamllabs/ocaml-ctypes/pull/683 as a patch on the released version of ctypes to help with testing.