### PR TITLE
Patch to remove Obj.set_tag in cubicle

### DIFF
--- a/packages/cubicle/cubicle.1.1.2+flambda2/files/0001-Replace-Obj.set_tag-with-Obj.with_tag.patch
+++ b/packages/cubicle/cubicle.1.1.2+flambda2/files/0001-Replace-Obj.set_tag-with-Obj.with_tag.patch
@@ -1,4 +1,4 @@
-From 0b2655b93f82857ff6babd0ce0c8f0f7fa3e7c9a Mon Sep 17 00:00:00 2001
+From 9bdb2c3f7fdfe89e3687f5b4372b0bfb3c7ad3da Mon Sep 17 00:00:00 2001
 From: Vincent Laviron <vincent.laviron@gmail.com>
 Date: Fri, 27 Aug 2021 14:45:31 +0200
 Subject: [PATCH] Replace Obj.set_tag with Obj.with_tag
@@ -11,7 +11,7 @@ Subject: [PATCH] Replace Obj.set_tag with Obj.with_tag
  4 files changed, 51 insertions(+), 27 deletions(-)
 
 diff --git a/enumerative.ml b/enumerative.ml
-index 7428c3e..2f18690 100644
+index 7428c3e..69f0dba 100644
 --- a/enumerative.ml
 +++ b/enumerative.ml
 @@ -47,14 +47,38 @@ module SLI = Set.Make (struct
@@ -168,7 +168,7 @@ index 7428c3e..2f18690 100644
 -  (* Prevent the GC from scanning the list env.states as it is going to be
 -     kept in memory all the time. *)
 -  List.iter (fun s -> Obj.set_tag (Obj.repr s) (Obj.no_scan_tag)) env.states
-+let no_scan_states env = env
++let no_scan_states env = ()
  
  let finalize_search env =
    let st = HST.stats env.explicit_states in

--- a/packages/cubicle/cubicle.1.1.2+flambda2/files/0001-Replace-Obj.set_tag-with-Obj.with_tag.patch
+++ b/packages/cubicle/cubicle.1.1.2+flambda2/files/0001-Replace-Obj.set_tag-with-Obj.with_tag.patch
@@ -1,17 +1,17 @@
-From 599fbf17765247d054a65a03eee23fb1a6bf19ae Mon Sep 17 00:00:00 2001
+From 0b2655b93f82857ff6babd0ce0c8f0f7fa3e7c9a Mon Sep 17 00:00:00 2001
 From: Vincent Laviron <vincent.laviron@gmail.com>
 Date: Fri, 27 Aug 2021 14:45:31 +0200
 Subject: [PATCH] Replace Obj.set_tag with Obj.with_tag
 
 ---
- enumerative.ml  | 60 ++++++++++++++++++++++++++++++++++---------------
- enumerative.mli |  5 ++++-
+ enumerative.ml  | 65 ++++++++++++++++++++++++++++++++-----------------
+ enumerative.mli |  5 +++-
  muparser.mly    |  6 ++---
  murphi.ml       |  2 +-
- 4 files changed, 50 insertions(+), 23 deletions(-)
+ 4 files changed, 51 insertions(+), 27 deletions(-)
 
 diff --git a/enumerative.ml b/enumerative.ml
-index 7428c3e..283a996 100644
+index 7428c3e..2f18690 100644
 --- a/enumerative.ml
 +++ b/enumerative.ml
 @@ -47,14 +47,38 @@ module SLI = Set.Make (struct
@@ -160,7 +160,19 @@ index 7428c3e..283a996 100644
    List.fold_left (apply_action env st) [st'] acts
  
  
-@@ -1197,7 +1221,7 @@ let finalize_search env =
+@@ -1181,10 +1205,7 @@ let shuffle d =
+     let sond = List.sort compare nd in
+     List.rev_map snd sond
+ 
+-let no_scan_states env =
+-  (* Prevent the GC from scanning the list env.states as it is going to be
+-     kept in memory all the time. *)
+-  List.iter (fun s -> Obj.set_tag (Obj.repr s) (Obj.no_scan_tag)) env.states
++let no_scan_states env = env
+ 
+ let finalize_search env =
+   let st = HST.stats env.explicit_states in
+@@ -1197,7 +1218,7 @@ let finalize_search env =
      printf "Buckets          : %d@." st.Hashtbl.num_buckets;
      printf "Max bucket size  : %d@." st.Hashtbl.max_bucket_length;
      printf "Bucket histogram : @?";
@@ -169,7 +181,7 @@ index 7428c3e..283a996 100644
        st.Hashtbl.bucket_histogram;
      printf "@.";
    end;
-@@ -1492,10 +1516,10 @@ let int_of_term env t =
+@@ -1492,10 +1513,10 @@ let int_of_term env t =
  
  let next_id env = env.pinf_int_abstr + 1
  

--- a/packages/cubicle/cubicle.1.1.2+flambda2/files/0001-Replace-Obj.set_tag-with-Obj.with_tag.patch
+++ b/packages/cubicle/cubicle.1.1.2+flambda2/files/0001-Replace-Obj.set_tag-with-Obj.with_tag.patch
@@ -1,0 +1,250 @@
+From 599fbf17765247d054a65a03eee23fb1a6bf19ae Mon Sep 17 00:00:00 2001
+From: Vincent Laviron <vincent.laviron@gmail.com>
+Date: Fri, 27 Aug 2021 14:45:31 +0200
+Subject: [PATCH] Replace Obj.set_tag with Obj.with_tag
+
+---
+ enumerative.ml  | 60 ++++++++++++++++++++++++++++++++++---------------
+ enumerative.mli |  5 ++++-
+ muparser.mly    |  6 ++---
+ murphi.ml       |  2 +-
+ 4 files changed, 50 insertions(+), 23 deletions(-)
+
+diff --git a/enumerative.ml b/enumerative.ml
+index 7428c3e..283a996 100644
+--- a/enumerative.ml
++++ b/enumerative.ml
+@@ -47,14 +47,38 @@ module SLI = Set.Make (struct
+ 
+ module TMap = Map.Make (Term)
+ 
+-type state = int array
++module State : sig
++  type t
++  val make : int -> int -> t
++  val copy : t -> t
++  val length : t -> int
++  val get : t -> int -> int
++  val set : t -> int -> int -> unit
++  val fold_left : ('a -> int -> 'a) -> 'a -> t -> 'a
++  val iteri : (int -> int -> unit) -> t -> unit
++  val as_array : t -> int array
++end = struct
++  type t = int array
++  let copy a = Obj.(obj (with_tag abstract_tag (repr a)))
++  let make len elt = copy (Array.make len elt)
++  let length = Array.length
++  let get = Array.get
++  let set = Array.set
++  let fold_left = Array.fold_left
++  let iteri = Array.iteri
++  let as_array x = x
++end
++
++module Array = State
+ 
++type state = State.t
++let state_as_array = State.as_array
+ 
+ type state_info = int HT.t
+ 
+ let equal_state a1 a2 =
+-  let n = Array.length a1 in
+-  let n2 = Array.length a2 in
++  let n = State.length a1 in
++  let n2 = State.length a2 in
+   if n <> n2 then false
+   else
+     let res = ref true in
+@@ -217,7 +241,7 @@ let id_to_term env id =
+ (* inefficient but only used for debug *)
+ let state_to_cube env st =
+   let i = ref 0 in
+-  Array.fold_left (fun sa sti ->
++  State.fold_left (fun sa sti ->
+     let sa = 
+       if sti <> -1 then
+ 	let t1 = id_to_term env !i in
+@@ -243,7 +267,7 @@ let swap a i j =
+ let swap_c a (i,j) = swap a i j
+ 
+ let apply_perm_state env st (_, p_vars, p_procs) =
+-  let st' = Array.copy st in
++  let st' = State.copy st in
+   List.iter (swap_c st') p_vars;
+   for i = 0 to env.nb_vars - 1 do
+     try let v = List.assoc st'.(i) p_procs in st'.(i) <- v
+@@ -313,7 +337,7 @@ let apply_subst_in_place env st sigma =
+   end
+ 
+ let apply_subst env st sigma =
+-  let st' = Array.copy st in
++  let st' = State.copy st in
+   apply_subst_in_place env st' sigma;
+   st'
+ 
+@@ -326,7 +350,7 @@ let find_subst_for_norm env st =
+   let met = ref [] in
+   let remaining = ref env.proc_ids in
+   let sigma = HI.create env.model_cardinal in
+-  for i = 0 to Array.length st - 1 do
++  for i = 0 to State.length st - 1 do
+     let v = st.(i) in
+     match !remaining with
+     | r :: tail ->
+@@ -365,13 +389,13 @@ let find_subst_for_norm2 sigma env st =
+   
+ 
+ let normalize_state env st =
+-  (* let old = Array.copy st in *)
++  (* let old = State.copy st in *)
+   let sigma = find_subst_for_norm env st in
+   apply_subst_in_place env st sigma (* ; *)
+   (* find_subst_for_norm2 sigma env st *)
+   (* ; *)
+   (* let same = ref true in *)
+-  (* for i = 0 to Array.length st - 1 do *)
++  (* for i = 0 to State.length st - 1 do *)
+   (*   same := !same && st.(i) = old.(i) *)
+   (* done; *)
+   (* if not !same then eprintf "\nNormalize :@.%a@.->@.%a@." *)
+@@ -631,7 +655,7 @@ let write_atom_to_states env sts = function
+       let l = ref [] in
+       for i2 = env.low_int_abstr to (if op = Lt then v2 - 1 else v2) do
+         List.iter (fun st ->
+-          let st = Array.copy st in
++          let st = State.copy st in
+           st.(i1) <- i2;
+           l := st :: !l
+         ) sts
+@@ -643,7 +667,7 @@ let write_atom_to_states env sts = function
+       let l = ref [] in
+       for i1 = (if op = Lt then v1 + 1 else v1) to env.up_int_abstr do
+         List.iter (fun st ->
+-          let st = Array.copy st in
++          let st = State.copy st in
+           st.(i2) <- i1;
+           l := st :: !l
+         ) sts
+@@ -668,7 +692,7 @@ let init_to_states env procs s =
+   let l_inits = mkinits procs s in
+   let sts =
+     List.fold_left (fun acc init -> 
+-      let st_init = Array.make nb (-1) in
++      let st_init = State.make nb (-1) in
+       let sts = write_cube_to_states env st_init init in
+       List.rev_append sts acc
+     ) [] l_inits in
+@@ -865,13 +889,13 @@ let rec apply_action env st sts' = function
+   | St_ite (reqs, a1, a2) -> (* explore both branches if possible *)
+       let sts'1 = 
+         if check_reqs env st reqs then 
+-          let sts' = List.map Array.copy sts' in 
++          let sts' = List.map State.copy sts' in 
+           apply_action env st sts' a1
+         else [] in
+       let sts'2 =
+         if List.exists (fun req -> check_req env st (neg_req env req)) reqs
+         then 
+-          let sts' = List.map Array.copy sts' in
++          let sts' = List.map State.copy sts' in
+           apply_action env st sts' a2
+         else [] in
+       begin
+@@ -884,7 +908,7 @@ let rec apply_action env st sts' = function
+   | _ (* St_ignore or St_arith when ignoring nums *) -> sts'
+ 
+ let apply_actions env st acts =
+-  let st' = Array.copy st in
++  let st' = State.copy st in
+   List.fold_left (apply_action env st) [st'] acts
+ 
+ 
+@@ -1197,7 +1221,7 @@ let finalize_search env =
+     printf "Buckets          : %d@." st.Hashtbl.num_buckets;
+     printf "Max bucket size  : %d@." st.Hashtbl.max_bucket_length;
+     printf "Bucket histogram : @?";
+-    Array.iteri (fun i v -> if v <> 0 then printf "[%d->%d]" i v )
++    Stdlib.Array.iteri (fun i v -> if v <> 0 then printf "[%d->%d]" i v )
+       st.Hashtbl.bucket_histogram;
+     printf "@.";
+   end;
+@@ -1492,10 +1516,10 @@ let int_of_term env t =
+ 
+ let next_id env = env.pinf_int_abstr + 1
+ 
+-let empty_state = [||]
++let empty_state = (Obj.magic [||] : state)
+ 
+ let new_undef_state env =
+-  Array.make env.nb_vars (-1)
++  State.make env.nb_vars (-1)
+   (* env.states <- st :: env.states; *)
+   (* eprintf "nb states : %d@." (List.length env.states); *)
+   (* st *)
+diff --git a/enumerative.mli b/enumerative.mli
+index 942ae30..668bdde 100644
+--- a/enumerative.mli
++++ b/enumerative.mli
+@@ -35,10 +35,13 @@ val smallest_to_resist_on_trace : Node.t list -> Node.t list
+ type env
+ (** The type of environments for enumerative explorations *)
+ 
+-type state = private int array
++type state
+ (** The type of states, we allow states to be constructed from the outside by
+     calling the function [new_undef_state]. *)
+ 
++(** Cast a state as an int array *)
++val state_as_array : state -> int array
++
+ val print_state : env -> Format.formatter -> state -> unit
+ (** Printing a state. It is decoded to an {!SAtom} in a very inefficient
+     manner. This function should only be used for debugging. *)
+diff --git a/muparser.mly b/muparser.mly
+index 0de3500..23fa2f3 100644
+--- a/muparser.mly
++++ b/muparser.mly
+@@ -120,7 +120,7 @@ affectation:
+         (* eprintf "%s -> %s@." v x; *)
+         let id_var = Hashtbl.find encoding v in
+         let id_value = Hashtbl.find encoding x in
+-        let si = (!st :> int array) in
++        let si = Enumerative.state_as_array !st in
+         si.(id_var) <- id_value
+       with Not_found -> ()
+     }
+@@ -130,7 +130,7 @@ affectation:
+     { try
+         let id_var = Hashtbl.find encoding $1 in
+         let id_value = Hashtbl.find encoding $3 in
+-        let si = (!st :> int array) in
++        let si = Enumerative.state_as_array !st in
+         si..(id_var) <- id_value
+       with Not_found -> ()
+     }
+@@ -146,7 +146,7 @@ trace_step:
+       if verbose > 0 then
+         printf "@ %a" (Enumerative.print_state !env) !st;
+       printf "@ @]@,";
+-      let si = (!st :> int array) in
++      let si = Enumerative.state_as_array !st in
+       for i = 0 to Array.length si - 1 do si.(i) <- -1 done
+     }
+ ;
+diff --git a/murphi.ml b/murphi.ml
+index 2eb3502..0596fd2 100644
+--- a/murphi.ml
++++ b/murphi.ml
+@@ -885,7 +885,7 @@ let simple_parser ic =
+                             (* eprintf "  %s -> %s@." v x; *)
+                             let id_var = Hashtbl.find encoding v in
+                             let id_value = Hashtbl.find encoding x in
+-                            let si = (!st :> int array) in
++                            let si = Enumerative.state_as_array !st in
+                             si.(id_var) <- id_value
+                           with Not_found -> ())
+                     done;
+-- 
+2.20.1
+

--- a/packages/cubicle/cubicle.1.1.2+flambda2/files/cubicle.install
+++ b/packages/cubicle/cubicle.1.1.2+flambda2/files/cubicle.install
@@ -1,0 +1,1 @@
+bin: ["cubicle.opt" {"cubicle"}]

--- a/packages/cubicle/cubicle.1.1.2+flambda2/opam
+++ b/packages/cubicle/cubicle.1.1.2+flambda2/opam
@@ -28,5 +28,5 @@ url {
   checksum: "md5=706b3405ea9400b6a1b21dec9c2cb02f"
 }
 patches: ["0001-Replace-Obj.set_tag-with-Obj.with_tag.patch"]
-extra-files: [ ["0001-Replace-Obj.set_tag-with-Obj.with_tag.patch" "md5=ea3361a272fe0a9be47e387f31c6272c"]
+extra-files: [ ["0001-Replace-Obj.set_tag-with-Obj.with_tag.patch" "md5=a97a9984a43c39a50a545c502f6c7ad0"]
                ["cubicle.install" "md5=ba6d18615d00544948c96638b6c8d900"] ]

--- a/packages/cubicle/cubicle.1.1.2+flambda2/opam
+++ b/packages/cubicle/cubicle.1.1.2+flambda2/opam
@@ -22,11 +22,11 @@ conflicts: [
   "functory" {< "0.5"}
 ]
 synopsis: "SMT based model checker for parameterized systems"
-extra-files: ["cubicle.install" "md5=ba6d18615d00544948c96638b6c8d900"]
 url {
   src:
     "https://github.com/cubicle-model-checker/cubicle/releases/download/1.1.2/cubicle-1.1.2.tar.gz"
   checksum: "md5=706b3405ea9400b6a1b21dec9c2cb02f"
 }
 patches: ["0001-Replace-Obj.set_tag-with-Obj.with_tag.patch"]
-extra-files: [ ["0001-Replace-Obj.set_tag-with-Obj.with_tag.patch" "md5=ea3361a272fe0a9be47e387f31c6272c"] ]
+extra-files: [ ["0001-Replace-Obj.set_tag-with-Obj.with_tag.patch" "md5=ea3361a272fe0a9be47e387f31c6272c"]
+               ["cubicle.install" "md5=ba6d18615d00544948c96638b6c8d900"] ]

--- a/packages/cubicle/cubicle.1.1.2+flambda2/opam
+++ b/packages/cubicle/cubicle.1.1.2+flambda2/opam
@@ -13,7 +13,7 @@ build: [
   [make]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.09.0"}
   "ocamlfind"
   "num"
 ]

--- a/packages/cubicle/cubicle.1.1.2+flambda2/opam
+++ b/packages/cubicle/cubicle.1.1.2+flambda2/opam
@@ -29,4 +29,4 @@ url {
   checksum: "md5=706b3405ea9400b6a1b21dec9c2cb02f"
 }
 patches: ["0001-Replace-Obj.set_tag-with-Obj.with_tag.patch"]
-extra-files: [ ["0001-Replace-Obj.set_tag-with-Obj.with_tag.patch" "md5=b9ab2d3420d32aee2e5cf66efb9bcfca"] ]
+extra-files: [ ["0001-Replace-Obj.set_tag-with-Obj.with_tag.patch" "md5=ea3361a272fe0a9be47e387f31c6272c"] ]

--- a/packages/cubicle/cubicle.1.1.2+flambda2/opam
+++ b/packages/cubicle/cubicle.1.1.2+flambda2/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "alainmebsout@gmail.com"
+authors: [
+  "Sylvain Conchon"
+  "Alain Mebsout"
+]
+homepage: "http://cubicle.lri.fr"
+license: "Apache-2.0"
+bug-reports: "https://github.com/cubicle-model-checker/cubicle/issues"
+dev-repo: "git+https://github.com/cubicle-model-checker/cubicle.git"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "ocamlfind"
+  "num"
+]
+depopts: ["functory"]
+conflicts: [
+  "functory" {< "0.5"}
+]
+synopsis: "SMT based model checker for parameterized systems"
+extra-files: ["cubicle.install" "md5=ba6d18615d00544948c96638b6c8d900"]
+url {
+  src:
+    "https://github.com/cubicle-model-checker/cubicle/releases/download/1.1.2/cubicle-1.1.2.tar.gz"
+  checksum: "md5=706b3405ea9400b6a1b21dec9c2cb02f"
+}
+patches: ["0001-Replace-Obj.set_tag-with-Obj.with_tag.patch"]
+extra-files: [ ["0001-Replace-Obj.set_tag-with-Obj.with_tag.patch" "md5=b9ab2d3420d32aee2e5cf66efb9bcfca"] ]


### PR DESCRIPTION
I may have gone slightly overboard... But as a result the patch could be submitted upstream if we want to.