### PR TITLE
Fix link flags for links-mysql

### DIFF
--- a/packages/links-mysql/links-mysql.0.9.3+flambda2/files/unix-link.patch
+++ b/packages/links-mysql/links-mysql.0.9.3+flambda2/files/unix-link.patch
@@ -1,0 +1,30 @@
+diff --git a/database/mysql-driver/dune b/database/mysql-driver/dune
+index c5a4ed03..ccd9c77a 100644
+--- a/database/mysql-driver/dune
++++ b/database/mysql-driver/dune
+@@ -3,8 +3,8 @@
+   (public_name links-mysql)
+   (synopsis "MySQL database backend for Links")
+   (optional)
+-  (flags (:standard -safe-string -dtypes -w Ae-44-45-60 -g -cclib -lunix -thread))
+-  (libraries mysql links.core))
++  (flags (:standard -safe-string -dtypes -w Ae-44-45-60 -g -thread))
++  (libraries unix mysql links.core))
+ 
+ 
+ (install
+diff --git a/database/mysql8-driver/dune b/database/mysql8-driver/dune
+index adfdb3ad..02c4fe17 100644
+--- a/database/mysql8-driver/dune
++++ b/database/mysql8-driver/dune
+@@ -3,8 +3,8 @@
+   (public_name links-mysql8)
+   (synopsis "MySQL8 database backend for Links")
+   (optional)
+-  (flags (:standard -safe-string -dtypes -w Ae-42-44-45-60 -g -cclib -lunix -thread))
+-  (libraries mysql8 links.core))
++  (flags (:standard -safe-string -dtypes -w Ae-42-44-45-60 -g -thread))
++  (libraries unix mysql8 links.core))
+ 
+ 
+ (install

--- a/packages/links-mysql/links-mysql.0.9.3+flambda2/opam
+++ b/packages/links-mysql/links-mysql.0.9.3+flambda2/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "James Cheney <jcheney@inf.ed.ac.uk>"
+authors: "The Links Team <links-dev@inf.ed.ac.uk>"
+synopsis: "MySQL database driver for the Links Programming Language"
+description: "MySQL database driver for the Links Programming Language"
+homepage: "https://github.com/links-lang/links"
+dev-repo: "git+https://github.com/links-lang/links.git"
+bug-reports: "https://github.com/links-lang/links/issues"
+license: "GPL-2.0-only"
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.10.0"}
+  "conf-mysql"
+  "mysql"
+  "links" {= version}
+]
+x-commit-hash: "6ec7f5bd54407cd68eddf906d8ff5002d02702dc"
+url {
+  src:
+    "https://github.com/links-lang/links/releases/download/0.9.3/links-0.9.3.tbz"
+  checksum: [
+    "sha256=f663eaafad4d80ce0f86bb8639bfd5cdd03e432cc4bd2868a0b4b50d2ee11de7"
+    "sha512=0f70d72e9d0eac2ddd7fb7905e4a5ea2136cfbffcd83d564026f847f1d90c02daaf70d8c84555c68a076867cf9f0913ae38d6b53ca6faaadbedbf20421aa83d8"
+  ]
+}

--- a/packages/links-mysql/links-mysql.0.9.3+flambda2/opam
+++ b/packages/links-mysql/links-mysql.0.9.3+flambda2/opam
@@ -29,3 +29,5 @@ url {
     "sha512=0f70d72e9d0eac2ddd7fb7905e4a5ea2136cfbffcd83d564026f847f1d90c02daaf70d8c84555c68a076867cf9f0913ae38d6b53ca6faaadbedbf20421aa83d8"
   ]
 }
+patches: ["unix-link.patch"]
+extra-files: [ ["unix-link.patch" "md5=5a11b90b5b1395aadff280eaad55406a"] ]

--- a/packages/links/links.0.9.3+flambda2/opam
+++ b/packages/links/links.0.9.3+flambda2/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "Simon Fowler <simon.fowler@ed.ac.uk>"
+authors: "The Links Team <links-dev@inf.ed.ac.uk>"
+synopsis: "The Links Programming Language"
+description: "Links is a functional programming language designed to make web programming easier."
+homepage: "https://github.com/links-lang/links"
+dev-repo: "git+https://github.com/links-lang/links.git"
+bug-reports: "https://github.com/links-lang/links/issues"
+license: "GPL-2.0-only"
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "exec" "--root" "." "preinstall/preinstall.exe" "--" "-libdir" _:lib ]
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.10.0"}
+  "ppx_deriving"
+  "ppx_deriving_yojson" {>= "3.3"}
+  "base64"
+  "linenoise"
+  "ANSITerminal"
+  "lwt" {>= "3.1.0"}
+  "cohttp"
+  "cohttp-lwt"
+  "cohttp-lwt-unix"
+  "conduit-lwt-unix"
+  "uri"
+  "websocket"
+  "websocket-lwt-unix"
+  "safepass"
+  "result"
+  "ocamlfind"
+  "menhir"
+  "ppx_sexp_conv"
+]
+x-commit-hash: "6ec7f5bd54407cd68eddf906d8ff5002d02702dc"
+url {
+  src:
+    "https://github.com/links-lang/links/releases/download/0.9.3/links-0.9.3.tbz"
+  checksum: [
+    "sha256=f663eaafad4d80ce0f86bb8639bfd5cdd03e432cc4bd2868a0b4b50d2ee11de7"
+    "sha512=0f70d72e9d0eac2ddd7fb7905e4a5ea2136cfbffcd83d564026f847f1d90c02daaf70d8c84555c68a076867cf9f0913ae38d6b53ca6faaadbedbf20421aa83d8"
+  ]
+}


### PR DESCRIPTION
The patch also fixes the dune file for `links-mysql8`, but I don't think it has any effect (I don't think `links-mysql8` is published on opam).

I've also included a fix for the build command of `links`, as it wouldn't build on my setup otherwise.