### PR TITLE
Fix build dir

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.12.0+flambda2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0+flambda2/opam
@@ -16,7 +16,7 @@ conflict-class: "ocaml-core-compiler"
 flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 install: [
-  ["sh" "-c" "cd \"${TMPDIR:-/tmp}\" && mv \"%{build}%\"/*.tar.gz . && tar xvf special_dune.tar.gz && tar xvf ocaml-4.12.0.tar.gz && cd ocaml-4.12.0 && ./configure \"--prefix=${TMPDIR:-/tmp}/ocaml\" && make -j%{jobs}% && make install && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" %{make}% -C \"${TMPDIR:-/tmp}/dune-special_dune\" release && cp \"${TMPDIR:-/tmp}/dune-special_dune/dune.exe\" \"%{build}%/\" && autoconf && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" ./configure \"--prefix=%{prefix}%\" --enable-middle-end=flambda2 \"--with-dune=%{build}%/dune.exe\" && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" \"%{make}%\" -j%{jobs}% && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" \"%{make}%\" install"]
+  ["sh" "-c" "cd \"${TMPDIR:-/tmp}\" && mv \"%{build}%\"/*.tar.gz . && tar xvf special_dune.tar.gz && tar xvf ocaml-4.12.0.tar.gz && cd ocaml-4.12.0 && ./configure \"--prefix=${TMPDIR:-/tmp}/ocaml\" && make -j%{jobs}% && make install && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" %{make}% -C \"${TMPDIR:-/tmp}/dune-special_dune\" release && cp \"${TMPDIR:-/tmp}/dune-special_dune/dune.exe\" \"%{build}%/\" && cd \"%{build}%\" && autoconf && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" ./configure \"--prefix=%{prefix}%\" --enable-middle-end=flambda2 \"--with-dune=%{build}%/dune.exe\" && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" \"%{make}%\" -j%{jobs}% && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" \"%{make}%\" install"]
 ]
 conflicts: [
   "ocaml-option-32bit"


### PR DESCRIPTION
We were compiling and installing the wrong compiler... I'm not sure exactly why we got the CI errors that we did though. The ones I get locally are slightly different (errors while loading either the interpreter or dynamically linked stubs), while on the CI results I saw messages suggesting ocamldoc wasn't installed at all.

In any cases, the patch discussed at https://github.com/ocaml-flambda/flambda-backend/issues/693 is still needed, but with these two patches I managed to successfully install the `inspect` package.