### PR TITLE
Add patches for Symbol changes

### DIFF
--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.4.0.0+flambda2/files/js_of_ocaml.patch
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.4.0.0+flambda2/files/js_of_ocaml.patch
@@ -1,0 +1,176 @@
+diff --git a/compiler/bin-js_of_ocaml/compile.ml b/compiler/bin-js_of_ocaml/compile.ml
+--- a/compiler/bin-js_of_ocaml/compile.ml
++++ b/compiler/bin-js_of_ocaml/compile.ml
+@@ -26,7 +26,8 @@ let debug_mem = Debug.find "mem"
+ let _ = Sys.catch_break true
+ 
+ let gen_unit_filename dir u =
+-  Filename.concat dir (Printf.sprintf "%s.js" u.Cmo_format.cu_name)
++  let name = u.Cmo_format.cu_name |> Compilation_unit.Name.to_string in
++  Filename.concat dir (Printf.sprintf "%s.js" name)
+ 
+ let run
+     { Cmd_arg.common
+@@ -278,8 +279,9 @@ let run
+             let code =
+               Parse_bytecode.from_cmo ~includes:paths ~toplevel ~debug:need_debug cmo ic
+             in
++            let name = cmo.cu_name |> Compilation_unit.Name.to_string in
+             if times ()
+-            then Format.eprintf "  parsing: %a (%s)@." Timer.print t1 cmo.cu_name;
++            then Format.eprintf "  parsing: %a (%s)@." Timer.print t1 name;
+             output code ~standalone:false output_file)
+     | `Cma cma ->
+         let t1 = Timer.make () in
+diff --git a/compiler/bin-js_of_ocaml/js_of_ocaml.ml b/compiler/bin-js_of_ocaml/js_of_ocaml.ml
+--- a/compiler/bin-js_of_ocaml/js_of_ocaml.ml
++++ b/compiler/bin-js_of_ocaml/js_of_ocaml.ml
+@@ -45,29 +45,30 @@ let _ =
+     | _ -> argv
+   in
+   try
+-    match
+-      Cmdliner.Term.eval_choice
+-        ~catch:false
+-        ~argv
+-        Compile.command_main
+-        [ Link.command
+-        ; Build_fs.command
+-        ; Build_runtime.command
+-        ; Print_runtime.command
+-        ; Check_runtime.command
+-        ; Compile.command
+-        ]
+-    with
+-    | `Ok () | `Help | `Version ->
+-        if !warnings > 0 && !werror
+-        then (
+-          Format.eprintf "%s: all warnings being treated as errors@." Sys.argv.(0);
+-          exit 1)
+-        else exit 0
+-    | `Error `Term -> exit 1
+-    | `Error `Parse -> exit 124
+-    | `Error `Exn -> ()
+-    (* should not happen *)
++    Sys.with_async_exns (fun () ->
++      match
++        Cmdliner.Term.eval_choice
++          ~catch:false
++          ~argv
++          Compile.command_main
++          [ Link.command
++          ; Build_fs.command
++          ; Build_runtime.command
++          ; Print_runtime.command
++          ; Check_runtime.command
++          ; Compile.command
++          ]
++      with
++      | `Ok () | `Help | `Version ->
++          if !warnings > 0 && !werror
++          then (
++            Format.eprintf "%s: all warnings being treated as errors@." Sys.argv.(0);
++            exit 1)
++          else exit 0
++      | `Error `Term -> exit 1
++      | `Error `Parse -> exit 124
++      | `Error `Exn -> ()
++      (* should not happen *))
+   with
+   | (Match_failure _ | Assert_failure _ | Not_found) as exc ->
+       let backtrace = Printexc.get_backtrace () in
+diff --git a/compiler/bin-jsoo_minify/jsoo_minify.ml b/compiler/bin-jsoo_minify/jsoo_minify.ml
+--- a/compiler/bin-jsoo_minify/jsoo_minify.ml
++++ b/compiler/bin-jsoo_minify/jsoo_minify.ml
+@@ -97,10 +97,11 @@ let main = Cmdliner.Term.(pure f $ Cmd_a
+ let _ =
+   Timer.init Sys.time;
+   try
+-    Cmdliner.Term.eval
+-      ~catch:false
+-      ~argv:(Jsoo_cmdline.normalize_argv ~warn:(warn "%s") Sys.argv)
+-      main
++    Sys.with_async_exns (fun () ->
++      Cmdliner.Term.eval
++        ~catch:false
++        ~argv:(Jsoo_cmdline.normalize_argv ~warn:(warn "%s") Sys.argv)
++        main)
+   with
+   | (Match_failure _ | Assert_failure _ | Not_found) as exc ->
+       let backtrace = Printexc.get_backtrace () in
+diff --git a/compiler/lib/generate.ml b/compiler/lib/generate.ml
+--- a/compiler/lib/generate.ml
++++ b/compiler/lib/generate.ml
+@@ -936,7 +936,9 @@ let _ =
+       bool (J.EBin (J.EqEq, cx, cy)));
+   register_bin_prim "caml_js_instanceof" `Pure (fun cx cy _ ->
+       bool (J.EBin (J.InstanceOf, cx, cy)));
+-  register_un_prim "caml_js_typeof" `Pure (fun cx _ -> J.EUn (J.Typeof, cx))
++  register_un_prim "caml_js_typeof" `Pure (fun cx _ -> J.EUn (J.Typeof, cx));
++  register_un_prim "caml_with_async_exns" `Mutator (fun closure loc ->
++      ecall closure [int 0] loc)
+ 
+ (* This is not correct when switching the js-string flag *)
+ (* {[
+diff --git a/compiler/lib/parse_bytecode.ml b/compiler/lib/parse_bytecode.ml
+--- a/compiler/lib/parse_bytecode.ml
++++ b/compiler/lib/parse_bytecode.ml
+@@ -2378,7 +2378,7 @@ let from_exe
+     then
+       Ocaml_compiler.Symtable.GlobalMap.fold
+         (fun id num acc ->
+-          if num > exception_ids && Ident.global id && is_module (Ident.name id)
++          if num > exception_ids && Ident.is_global id && is_module (Ident.name id)
+           then StringSet.add (Ident.name id) acc
+           else acc)
+         symbols
+@@ -2562,7 +2562,7 @@ let from_compilation_units ~includes:_ ~
+     if toplevel && Config.Flag.include_cmis ()
+     then
+       List.fold_left l ~init:StringSet.empty ~f:(fun acc (compunit, _) ->
+-          StringSet.add compunit.Cmo_format.cu_name acc)
++          StringSet.add (compunit.Cmo_format.cu_name |> Compilation_unit.Name.to_string) acc)
+     else StringSet.empty
+   in
+   { code = prepend prog body; cmis; debug = debug_data }
+@@ -2621,7 +2621,7 @@ let from_channel ic =
+           then raise Magic_number.(Bad_magic_version magic);
+           let compunit_pos = input_binary_int ic in
+           seek_in ic compunit_pos;
+-          let compunit : Cmo_format.compilation_unit = input_value ic in
++          let compunit : Cmo_format.compilation_unit_descr = input_value ic in
+           `Cmo compunit
+       | `Cma ->
+           if Config.Flag.check_magic ()
+diff --git a/compiler/lib/parse_bytecode.mli b/compiler/lib/parse_bytecode.mli
+--- a/compiler/lib/parse_bytecode.mli
++++ b/compiler/lib/parse_bytecode.mli
+@@ -59,7 +59,7 @@ val from_cmo :
+      ?includes:string list
+   -> ?toplevel:bool
+   -> ?debug:bool
+-  -> Cmo_format.compilation_unit
++  -> Cmo_format.compilation_unit_descr
+   -> in_channel
+   -> one
+ 
+@@ -73,7 +73,7 @@ val from_cma :
+ 
+ val from_channel :
+      in_channel
+-  -> [ `Cmo of Cmo_format.compilation_unit | `Cma of Cmo_format.library | `Exe ]
++  -> [ `Cmo of Cmo_format.compilation_unit_descr | `Cma of Cmo_format.library | `Exe ]
+ 
+ val from_string : string array -> string -> Code.program * Debug.t
+ 
+diff --git a/toplevel/bin/jsoo_common.ml b/toplevel/bin/jsoo_common.ml
+--- a/toplevel/bin/jsoo_common.ml
++++ b/toplevel/bin/jsoo_common.ml
+@@ -63,6 +63,7 @@ let cmis_of_cma ~dir cma_path =
+   let contains = unit_of_cma cma_path in
+   let dir = Filename.dirname cma_path in
+   List.filter_map contains ~f:(fun s ->
++      let s = s |> Compilation_unit.Name.to_string in
+       try Some (read_cmi ~dir (s ^ ".cmi")) with Not_found -> None)
+ 
+ let cmis_of_package pkg : string list =

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.4.0.0+flambda2/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.4.0.0+flambda2/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license:
+  "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.04" & < "4.15"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.15.0"}
+  "re" {with-test}
+  "cmdliner" {>= "1.0.0"}
+  "menhir"
+  "menhirLib"
+  "menhirSdk"
+  "yojson"
+  "odoc" {with-doc}
+]
+depopts: ["ocamlfind"]
+conflicts: [
+  "ocamlfind" {< "1.5.1"}
+  "js_of_ocaml" {< "3.0"}
+  "base-domains"
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/4.0.0/js_of_ocaml-4.0.0.tbz"
+  checksum: [
+    "sha256=df02f819e5b2f48234af2b3e3e7c9781afa8212f8bece7ebcfbd8358b394495e"
+    "sha512=92e822849c8be14ce0428f7f4be3991449f76e65d408073a5b8b9674ba2d099439027aa11618b603c7ee31a179cf6976d54a929917a69b269425f0367926c200"
+  ]
+}
+x-commit-hash: "6fb1d008061b6c028c375b240882bb735d54a5bc"
+patches: ["js_of_ocaml.patch"]
+extra-files: [ ["js_of_ocaml.patch" "md5=94e0fbbd912a4bb87a5da4d74d5e7535"] ]

--- a/packages/js_of_ocaml/js_of_ocaml.4.0.0+flambda2/files/js_of_ocaml.patch
+++ b/packages/js_of_ocaml/js_of_ocaml.4.0.0+flambda2/files/js_of_ocaml.patch
@@ -1,0 +1,176 @@
+diff --git a/compiler/bin-js_of_ocaml/compile.ml b/compiler/bin-js_of_ocaml/compile.ml
+--- a/compiler/bin-js_of_ocaml/compile.ml
++++ b/compiler/bin-js_of_ocaml/compile.ml
+@@ -26,7 +26,8 @@ let debug_mem = Debug.find "mem"
+ let _ = Sys.catch_break true
+ 
+ let gen_unit_filename dir u =
+-  Filename.concat dir (Printf.sprintf "%s.js" u.Cmo_format.cu_name)
++  let name = u.Cmo_format.cu_name |> Compilation_unit.Name.to_string in
++  Filename.concat dir (Printf.sprintf "%s.js" name)
+ 
+ let run
+     { Cmd_arg.common
+@@ -278,8 +279,9 @@ let run
+             let code =
+               Parse_bytecode.from_cmo ~includes:paths ~toplevel ~debug:need_debug cmo ic
+             in
++            let name = cmo.cu_name |> Compilation_unit.Name.to_string in
+             if times ()
+-            then Format.eprintf "  parsing: %a (%s)@." Timer.print t1 cmo.cu_name;
++            then Format.eprintf "  parsing: %a (%s)@." Timer.print t1 name;
+             output code ~standalone:false output_file)
+     | `Cma cma ->
+         let t1 = Timer.make () in
+diff --git a/compiler/bin-js_of_ocaml/js_of_ocaml.ml b/compiler/bin-js_of_ocaml/js_of_ocaml.ml
+--- a/compiler/bin-js_of_ocaml/js_of_ocaml.ml
++++ b/compiler/bin-js_of_ocaml/js_of_ocaml.ml
+@@ -45,29 +45,30 @@ let _ =
+     | _ -> argv
+   in
+   try
+-    match
+-      Cmdliner.Term.eval_choice
+-        ~catch:false
+-        ~argv
+-        Compile.command_main
+-        [ Link.command
+-        ; Build_fs.command
+-        ; Build_runtime.command
+-        ; Print_runtime.command
+-        ; Check_runtime.command
+-        ; Compile.command
+-        ]
+-    with
+-    | `Ok () | `Help | `Version ->
+-        if !warnings > 0 && !werror
+-        then (
+-          Format.eprintf "%s: all warnings being treated as errors@." Sys.argv.(0);
+-          exit 1)
+-        else exit 0
+-    | `Error `Term -> exit 1
+-    | `Error `Parse -> exit 124
+-    | `Error `Exn -> ()
+-    (* should not happen *)
++    Sys.with_async_exns (fun () ->
++      match
++        Cmdliner.Term.eval_choice
++          ~catch:false
++          ~argv
++          Compile.command_main
++          [ Link.command
++          ; Build_fs.command
++          ; Build_runtime.command
++          ; Print_runtime.command
++          ; Check_runtime.command
++          ; Compile.command
++          ]
++      with
++      | `Ok () | `Help | `Version ->
++          if !warnings > 0 && !werror
++          then (
++            Format.eprintf "%s: all warnings being treated as errors@." Sys.argv.(0);
++            exit 1)
++          else exit 0
++      | `Error `Term -> exit 1
++      | `Error `Parse -> exit 124
++      | `Error `Exn -> ()
++      (* should not happen *))
+   with
+   | (Match_failure _ | Assert_failure _ | Not_found) as exc ->
+       let backtrace = Printexc.get_backtrace () in
+diff --git a/compiler/bin-jsoo_minify/jsoo_minify.ml b/compiler/bin-jsoo_minify/jsoo_minify.ml
+--- a/compiler/bin-jsoo_minify/jsoo_minify.ml
++++ b/compiler/bin-jsoo_minify/jsoo_minify.ml
+@@ -97,10 +97,11 @@ let main = Cmdliner.Term.(pure f $ Cmd_a
+ let _ =
+   Timer.init Sys.time;
+   try
+-    Cmdliner.Term.eval
+-      ~catch:false
+-      ~argv:(Jsoo_cmdline.normalize_argv ~warn:(warn "%s") Sys.argv)
+-      main
++    Sys.with_async_exns (fun () ->
++      Cmdliner.Term.eval
++        ~catch:false
++        ~argv:(Jsoo_cmdline.normalize_argv ~warn:(warn "%s") Sys.argv)
++        main)
+   with
+   | (Match_failure _ | Assert_failure _ | Not_found) as exc ->
+       let backtrace = Printexc.get_backtrace () in
+diff --git a/compiler/lib/generate.ml b/compiler/lib/generate.ml
+--- a/compiler/lib/generate.ml
++++ b/compiler/lib/generate.ml
+@@ -936,7 +936,9 @@ let _ =
+       bool (J.EBin (J.EqEq, cx, cy)));
+   register_bin_prim "caml_js_instanceof" `Pure (fun cx cy _ ->
+       bool (J.EBin (J.InstanceOf, cx, cy)));
+-  register_un_prim "caml_js_typeof" `Pure (fun cx _ -> J.EUn (J.Typeof, cx))
++  register_un_prim "caml_js_typeof" `Pure (fun cx _ -> J.EUn (J.Typeof, cx));
++  register_un_prim "caml_with_async_exns" `Mutator (fun closure loc ->
++      ecall closure [int 0] loc)
+ 
+ (* This is not correct when switching the js-string flag *)
+ (* {[
+diff --git a/compiler/lib/parse_bytecode.ml b/compiler/lib/parse_bytecode.ml
+--- a/compiler/lib/parse_bytecode.ml
++++ b/compiler/lib/parse_bytecode.ml
+@@ -2378,7 +2378,7 @@ let from_exe
+     then
+       Ocaml_compiler.Symtable.GlobalMap.fold
+         (fun id num acc ->
+-          if num > exception_ids && Ident.global id && is_module (Ident.name id)
++          if num > exception_ids && Ident.is_global id && is_module (Ident.name id)
+           then StringSet.add (Ident.name id) acc
+           else acc)
+         symbols
+@@ -2562,7 +2562,7 @@ let from_compilation_units ~includes:_ ~
+     if toplevel && Config.Flag.include_cmis ()
+     then
+       List.fold_left l ~init:StringSet.empty ~f:(fun acc (compunit, _) ->
+-          StringSet.add compunit.Cmo_format.cu_name acc)
++          StringSet.add (compunit.Cmo_format.cu_name |> Compilation_unit.Name.to_string) acc)
+     else StringSet.empty
+   in
+   { code = prepend prog body; cmis; debug = debug_data }
+@@ -2621,7 +2621,7 @@ let from_channel ic =
+           then raise Magic_number.(Bad_magic_version magic);
+           let compunit_pos = input_binary_int ic in
+           seek_in ic compunit_pos;
+-          let compunit : Cmo_format.compilation_unit = input_value ic in
++          let compunit : Cmo_format.compilation_unit_descr = input_value ic in
+           `Cmo compunit
+       | `Cma ->
+           if Config.Flag.check_magic ()
+diff --git a/compiler/lib/parse_bytecode.mli b/compiler/lib/parse_bytecode.mli
+--- a/compiler/lib/parse_bytecode.mli
++++ b/compiler/lib/parse_bytecode.mli
+@@ -59,7 +59,7 @@ val from_cmo :
+      ?includes:string list
+   -> ?toplevel:bool
+   -> ?debug:bool
+-  -> Cmo_format.compilation_unit
++  -> Cmo_format.compilation_unit_descr
+   -> in_channel
+   -> one
+ 
+@@ -73,7 +73,7 @@ val from_cma :
+ 
+ val from_channel :
+      in_channel
+-  -> [ `Cmo of Cmo_format.compilation_unit | `Cma of Cmo_format.library | `Exe ]
++  -> [ `Cmo of Cmo_format.compilation_unit_descr | `Cma of Cmo_format.library | `Exe ]
+ 
+ val from_string : string array -> string -> Code.program * Debug.t
+ 
+diff --git a/toplevel/bin/jsoo_common.ml b/toplevel/bin/jsoo_common.ml
+--- a/toplevel/bin/jsoo_common.ml
++++ b/toplevel/bin/jsoo_common.ml
+@@ -63,6 +63,7 @@ let cmis_of_cma ~dir cma_path =
+   let contains = unit_of_cma cma_path in
+   let dir = Filename.dirname cma_path in
+   List.filter_map contains ~f:(fun s ->
++      let s = s |> Compilation_unit.Name.to_string in
+       try Some (read_cmi ~dir (s ^ ".cmi")) with Not_found -> None)
+ 
+ let cmis_of_package pkg : string list =

--- a/packages/js_of_ocaml/js_of_ocaml.4.0.0+flambda2/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.4.0.0+flambda2/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license:
+  "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.04"}
+  "js_of_ocaml-compiler" {= version}
+  "ppxlib" {>= "0.15"}
+  "uchar"
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/4.0.0/js_of_ocaml-4.0.0.tbz"
+  checksum: [
+    "sha256=df02f819e5b2f48234af2b3e3e7c9781afa8212f8bece7ebcfbd8358b394495e"
+    "sha512=92e822849c8be14ce0428f7f4be3991449f76e65d408073a5b8b9674ba2d099439027aa11618b603c7ee31a179cf6976d54a929917a69b269425f0367926c200"
+  ]
+}
+x-commit-hash: "6fb1d008061b6c028c375b240882bb735d54a5bc"
+patches: ["js_of_ocaml.patch"]
+extra-files: [ ["js_of_ocaml.patch" "md5=94e0fbbd912a4bb87a5da4d74d5e7535"] ]

--- a/packages/ocaml-compiler-libs/ocaml-compiler-libs.v0.12.4/files/read_cma.patch
+++ b/packages/ocaml-compiler-libs/ocaml-compiler-libs.v0.12.4/files/read_cma.patch
@@ -1,0 +1,11 @@
+diff --git a/src/read_cma/read_cma.ml b/src/read_cma/read_cma.ml
+--- a/src/read_cma/read_cma.ml
++++ b/src/read_cma/read_cma.ml
+@@ -11,5 +11,6 @@ let units fn =
+   let toc = (input_value ic : Cmo_format.library) in
+   close_in ic;
+ 
+-  List.map toc.lib_units ~f:(fun cu -> cu.Cmo_format.cu_name)
++  List.map toc.lib_units
++    ~f:(fun cu -> cu.Cmo_format.cu_name |> Compilation_unit.Name.to_string)
+   |> List.sort ~cmp:String.compare

--- a/packages/ocaml-compiler-libs/ocaml-compiler-libs.v0.12.4/opam
+++ b/packages/ocaml-compiler-libs/ocaml-compiler-libs.v0.12.4/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "OCaml compiler libraries repackaged"
+description: """
+This packages exposes the OCaml compiler libraries repackages under
+the toplevel names Ocaml_common, Ocaml_bytecomp, Ocaml_optcomp, ..."""
+maintainer: ["Jane Street developers"]
+authors: ["Jane Street Group, LLC"]
+license: "MIT"
+homepage: "https://github.com/janestreet/ocaml-compiler-libs"
+bug-reports: "https://github.com/janestreet/ocaml-compiler-libs/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.04.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/janestreet/ocaml-compiler-libs.git"
+url {
+  src:
+    "https://github.com/janestreet/ocaml-compiler-libs/releases/download/v0.12.4/ocaml-compiler-libs-v0.12.4.tbz"
+  checksum: [
+    "sha256=4ec9c9ec35cc45c18c7a143761154ef1d7663036a29297f80381f47981a07760"
+    "sha512=978dba8dfa61f98fa24fda7a9c26c2e837081f37d1685fe636dc19cfc3278a940cf01a10293504b185c406706bc1008bc54313d50f023bcdea6d5ac6c0788b35"
+  ]
+}
+x-commit-hash: "8cd12f18bb7171c2b67d661868c4271fae528d93"
+patches: ["read_cma.patch"]
+extra-files: [ ["read_cma.patch" "md5=2ebb9731c60412575f27f3af2293a2a9"] ]


### PR DESCRIPTION
This should unblock packages that depend on `ppxlib` and `js_of_ocaml`.