### PR TITLE
Add sigaltstack patches

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.12.0+flambda1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0+flambda1/opam
@@ -16,7 +16,7 @@ conflict-class: "ocaml-core-compiler"
 flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 install: [
-  ["sh" "-c" "cd \"${TMPDIR:-/tmp}\" && mv \"%{build}%\"/*.tar.gz . && tar xvf special_dune.tar.gz && tar xvf ocaml-4.12.0.tar.gz && cd ocaml-4.12.0 && ./configure \"--prefix=${TMPDIR:-/tmp}/ocaml\" && make -j%{jobs}% && make install && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" %{make}% -C \"${TMPDIR:-/tmp}/dune-special_dune\" release && cp \"${TMPDIR:-/tmp}/dune-special_dune/dune.exe\" \"%{build}%/\" && cd \"%{build}%\" && autoconf && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" ./configure \"--prefix=%{prefix}%\" --enable-middle-end=flambda \"--with-dune=%{build}%/dune.exe\" && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" \"%{make}%\" -j%{jobs}% && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" \"%{make}%\" install"]
+  ["sh" "-c" "cd \"${TMPDIR:-/tmp}\" && mv \"%{build}%\"/*.tar.gz . && tar xvf special_dune.tar.gz && tar xvf ocaml-4.12.0.tar.gz && cd ocaml-4.12.0 && patch -p0 ../alt-signal-stack.patch && ./configure \"--prefix=${TMPDIR:-/tmp}/ocaml\" && make -j%{jobs}% && make install && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" %{make}% -C \"${TMPDIR:-/tmp}/dune-special_dune\" release && cp \"${TMPDIR:-/tmp}/dune-special_dune/dune.exe\" \"%{build}%/\" && cd \"%{build}%\" && autoconf && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" ./configure \"--prefix=%{prefix}%\" --enable-middle-end=flambda \"--with-dune=%{build}%/dune.exe\" && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" \"%{make}%\" -j%{jobs}% && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" \"%{make}%\" install"]
 ]
 conflicts: [
   "ocaml-option-32bit"
@@ -40,4 +40,8 @@ extra-source "ocaml-4.12.0.tar.gz" {
 }
 url {
   src: "git+https://github.com/ocaml-flambda/flambda-backend.git"
+}
+extra-source "alt-signal-stack.patch" {
+  src: "https://github.com/ocaml/ocaml/commit/1eeb0e7fe595f5f9e1ea1edbdf785ff3b49feeeb.patch"
+  checksum: "sha256=59de25b95409c1927c4b607fb4b1218ff7623fca45474448c8e114a42853e3ad"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.12.0+flambda2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0+flambda2/opam
@@ -16,7 +16,7 @@ conflict-class: "ocaml-core-compiler"
 flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 install: [
-  ["sh" "-c" "cd \"${TMPDIR:-/tmp}\" && mv \"%{build}%\"/*.tar.gz . && tar xvf special_dune.tar.gz && tar xvf ocaml-4.12.0.tar.gz && cd ocaml-4.12.0 && ./configure \"--prefix=${TMPDIR:-/tmp}/ocaml\" && make -j%{jobs}% && make install && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" %{make}% -C \"${TMPDIR:-/tmp}/dune-special_dune\" release && cp \"${TMPDIR:-/tmp}/dune-special_dune/dune.exe\" \"%{build}%/\" && cd \"%{build}%\" && autoconf && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" ./configure \"--prefix=%{prefix}%\" --enable-middle-end=flambda2 \"--with-dune=%{build}%/dune.exe\" && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" \"%{make}%\" -j%{jobs}% && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" \"%{make}%\" install"]
+  ["sh" "-c" "cd \"${TMPDIR:-/tmp}\" && mv \"%{build}%\"/*.tar.gz . && tar xvf special_dune.tar.gz && tar xvf ocaml-4.12.0.tar.gz && cd ocaml-4.12.0 && patch -p0 ../alt-signal-stack.patch && ./configure \"--prefix=${TMPDIR:-/tmp}/ocaml\" && make -j%{jobs}% && make install && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" %{make}% -C \"${TMPDIR:-/tmp}/dune-special_dune\" release && cp \"${TMPDIR:-/tmp}/dune-special_dune/dune.exe\" \"%{build}%/\" && cd \"%{build}%\" && autoconf && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" ./configure \"--prefix=%{prefix}%\" --enable-middle-end=flambda2 \"--with-dune=%{build}%/dune.exe\" && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" \"%{make}%\" -j%{jobs}% && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" \"%{make}%\" install"]
 ]
 conflicts: [
   "ocaml-option-32bit"
@@ -40,4 +40,8 @@ extra-source "ocaml-4.12.0.tar.gz" {
 }
 url {
   src: "git+https://github.com/ocaml-flambda/flambda-backend.git"
+}
+extra-source "alt-signal-stack.patch" {
+  src: "https://github.com/ocaml/ocaml/commit/1eeb0e7fe595f5f9e1ea1edbdf785ff3b49feeeb.patch"
+  checksum: "sha256=59de25b95409c1927c4b607fb4b1218ff7623fca45474448c8e114a42853e3ad"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.12.0+pr867+flambda2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0+pr867+flambda2/opam
@@ -16,7 +16,7 @@ conflict-class: "ocaml-core-compiler"
 flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 install: [
-  ["sh" "-c" "cd \"${TMPDIR:-/tmp}\" && mv \"%{build}%\"/*.tar.gz . && tar xvf special_dune.tar.gz && tar xvf ocaml-4.12.0.tar.gz && cd ocaml-4.12.0 && ./configure \"--prefix=${TMPDIR:-/tmp}/ocaml\" && make -j%{jobs}% && make install && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" %{make}% -C \"${TMPDIR:-/tmp}/dune-special_dune\" release && cp \"${TMPDIR:-/tmp}/dune-special_dune/dune.exe\" \"%{build}%/\" && cd \"%{build}%\" && autoconf && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" ./configure \"--prefix=%{prefix}%\" --enable-middle-end=flambda2 \"--with-dune=%{build}%/dune.exe\" && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" \"%{make}%\" -j%{jobs}% && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" \"%{make}%\" install"]
+  ["sh" "-c" "cd \"${TMPDIR:-/tmp}\" && mv \"%{build}%\"/*.tar.gz . && tar xvf special_dune.tar.gz && tar xvf ocaml-4.12.0.tar.gz && cd ocaml-4.12.0 && patch -p0 ../alt-signal-stack.patch && ./configure \"--prefix=${TMPDIR:-/tmp}/ocaml\" && make -j%{jobs}% && make install && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" %{make}% -C \"${TMPDIR:-/tmp}/dune-special_dune\" release && cp \"${TMPDIR:-/tmp}/dune-special_dune/dune.exe\" \"%{build}%/\" && cd \"%{build}%\" && autoconf && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" ./configure \"--prefix=%{prefix}%\" --enable-middle-end=flambda2 \"--with-dune=%{build}%/dune.exe\" && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" \"%{make}%\" -j%{jobs}% && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" \"%{make}%\" install"]
 ]
 conflicts: [
   "ocaml-option-32bit"
@@ -40,4 +40,8 @@ extra-source "ocaml-4.12.0.tar.gz" {
 }
 url {
   src: "git+https://github.com/Gbury/flambda-backend.git#ref-to-variables"
+}
+extra-source "alt-signal-stack.patch" {
+  src: "https://github.com/ocaml/ocaml/commit/1eeb0e7fe595f5f9e1ea1edbdf785ff3b49feeeb.patch"
+  checksum: "sha256=59de25b95409c1927c4b607fb4b1218ff7623fca45474448c8e114a42853e3ad"
 }


### PR DESCRIPTION
@Gbury reported that creating a switch using this repo failed due to sigaltstack errors.
I've taken some inspiration from the official 4.12.0 patches to fix the issue here too.
Note that the issue is not that the flambda-backend compilers don't have the patch (they do, I believe), but that the vanilla 4.12.0 compiler used as bootstrap doesn't.

@kit-ty-kate I would appreciate if you could have a quick look that I haven't done anything obviously wrong.