### PR TITLE
Add constraints on patches incompatible with vanilla 4.12

### DIFF
--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.4.0.0+flambda2/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.4.0.0+flambda2/opam
@@ -11,7 +11,7 @@ doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
 bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
 depends: [
   "dune" {>= "2.9"}
-  "ocaml" {>= "4.04" & < "4.15"}
+  "ocaml-variants" {= "4.12.0+flambda1" | = "4.12.0+flambda2"| = "4.12.0+pr867+flambda2" }
   "num" {with-test}
   "ppx_expect" {>= "v0.14.2" & with-test}
   "ppxlib" {>= "0.15.0"}

--- a/packages/js_of_ocaml/js_of_ocaml.4.0.0+flambda2/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.4.0.0+flambda2/opam
@@ -11,7 +11,7 @@ doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
 bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
 depends: [
   "dune" {>= "2.9"}
-  "ocaml" {>= "4.04"}
+  "ocaml-variants" {= "4.12.0+flambda1" | = "4.12.0+flambda2"| = "4.12.0+pr867+flambda2" }
   "js_of_ocaml-compiler" {= version}
   "ppxlib" {>= "0.15"}
   "uchar"

--- a/packages/ocaml-compiler-libs/ocaml-compiler-libs.v0.12.4/opam
+++ b/packages/ocaml-compiler-libs/ocaml-compiler-libs.v0.12.4/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/janestreet/ocaml-compiler-libs"
 bug-reports: "https://github.com/janestreet/ocaml-compiler-libs/issues"
 depends: [
   "dune" {>= "2.8"}
-  "ocaml" {>= "4.04.1"}
+  "ocaml-variants" {= "4.12.0+flambda1" | = "4.12.0+flambda2"| = "4.12.0+pr867+flambda2" }
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
The patches in #12 are incompatible with the vanilla compiler. I put together this patch for unblocking the situation, but I suspect that there are cleaner ways to handle that. Suggestions welcome.