### PR TITLE
Add patch for the compilation of ocamlbuild with the new flambda2 compiler

### DIFF
--- a/packages/ocamlbuild/ocamlbuild.0.14.2/files/flambda2.patch
+++ b/packages/ocamlbuild/ocamlbuild.0.14.2/files/flambda2.patch
@@ -1,0 +1,49 @@
+diff --git a/Makefile b/Makefile
+index 12a2201..2f78414 100644
+--- a/Makefile
++++ b/Makefile
+@@ -418,10 +418,22 @@ endif
+ 
+ # The generic rules
+ 
+-%.cmo: %.ml
++src/%.cmo: src/%.ml
++	$(OCAMLC) -for-pack Ocamlbuild_pack $(COMPFLAGS) -c $<
++
++bin/%.cmo: bin/%.ml
++	$(OCAMLC) $(COMPFLAGS) -c $<
++
++plugin-lib/%.cmo: plugin-lib/%.ml
++	$(OCAMLC) $(COMPFLAGS) -c $<
++
++src/%.cmi: src/%.mli
++	$(OCAMLC) -for-pack Ocamlbuild_pack $(COMPFLAGS) -c $<
++
++bin/%.cmi: bin/%.mli
+ 	$(OCAMLC) $(COMPFLAGS) -c $<
+ 
+-%.cmi: %.mli
++plugin-lib/%.cmi: plugin-lib/%.mli
+ 	$(OCAMLC) $(COMPFLAGS) -c $<
+ 
+ src/%.cmx: src/%.ml
+diff --git a/src/configuration.ml b/src/configuration.ml
+index a209df5..f7120da 100644
+--- a/src/configuration.ml
++++ b/src/configuration.ml
+@@ -58,6 +58,15 @@ let apply_config s (config : t) init =
+   List.fold_left begin fun tags (key, v) ->
+     if key_match key s then
+       List.fold_right add v.plus_tags (List.fold_right remove v.minus_tags tags)
++    else if
++         String.length s >= 4
++      && List.mem (String.sub s (String.length s - 4) 4) [".cmi"; ".cmo"]
++      && key_match key (String.sub s 0 (String.length s - 4) ^ ".cmx")
++    then
++      let only_for_pack l =
++        List.filter (fun (tag, _) -> String.length tag >= 9 && String.sub tag 0 9 = "for-pack(") l
++      in
++      List.fold_right add (only_for_pack v.plus_tags) (List.fold_right remove (only_for_pack v.minus_tags) tags)
+     else tags
+   end init config
+ 

--- a/packages/ocamlbuild/ocamlbuild.0.14.2/opam
+++ b/packages/ocamlbuild/ocamlbuild.0.14.2/opam
@@ -1,0 +1,43 @@
+
+opam-version: "2.0"
+synopsis:
+  "OCamlbuild is a build system with builtin rules to easily build most OCaml projects"
+maintainer: "Gabriel Scherer <gabriel.scherer@gmail.com>"
+authors: ["Nicolas Pouillard" "Berke Durak"]
+license: "LGPL-2.0-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/ocaml/ocamlbuild/"
+doc: "https://github.com/ocaml/ocamlbuild/blob/master/manual/manual.adoc"
+bug-reports: "https://github.com/ocaml/ocamlbuild/issues"
+depends: [
+  "base-flambda2"
+  "ocaml" {>= "4.03"}
+]
+conflicts: [
+  "base-ocamlbuild"
+  "ocamlfind" {< "1.6.2"}
+]
+build: [
+  [
+    make
+    "-f"
+    "configure.make"
+    "all"
+    "OCAMLBUILD_PREFIX=%{prefix}%"
+    "OCAMLBUILD_BINDIR=%{bin}%"
+    "OCAMLBUILD_LIBDIR=%{lib}%"
+    "OCAMLBUILD_MANDIR=%{man}%"
+    "OCAML_NATIVE=%{ocaml:native}%"
+    "OCAML_NATIVE_TOOLS=%{ocaml:native}%"
+  ]
+  [make "check-if-preinstalled" "all" "opam-install"]
+]
+dev-repo: "git+https://github.com/ocaml/ocamlbuild.git"
+url {
+  src: "https://github.com/ocaml/ocamlbuild/archive/refs/tags/0.14.2.tar.gz"
+  checksum: [
+    "md5=2f407fadd57b073155a6aead887d9676"
+    "sha512=f568bf10431a1f701e8bd7554dc662400a0d978411038bbad93d44dceab02874490a8a5886a9b44e017347e7949997f13f5c3752f74e1eb5e273d2beb19a75fd"
+  ]
+}
+patches: ["flambda2.patch"]
+extra-files: [ ["flambda2.patch" "md5=c17a3cfde2f575cfb4e80ef4a430a4f6"] ]


### PR DESCRIPTION
Flambda2 requires `-for-pack` to be added as an option when compiling `.mli` files to be used in a pack. The patch added does two things: first, it fixes the compilation of ocamlbuild by making sure to use `for-pack` for its `.mli` files, and secondly, it adds a hack so that rules adding `-for-pack` to the compilation targets for `.cmx` files will also add them to compilation targets for `.cmi` and `.cmo` files. Note that this is not enough to always fix the compilation: if there is a `.mli`-only file, and the files for the pack are listed explicitely and not with a wildcard, this `.mli` might be missing `-for-pack` when compiling, so this is only a best-effort.