### PR TITLE
Use legacy library layout

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.14.1+flambda1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.1+flambda1/opam
@@ -17,7 +17,7 @@ conflict-class: "ocaml-core-compiler"
 flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 install: [
-  ["sh" "-c" "cd \"${TMPDIR:-/tmp}\" && mv \"%{build}%\"/*.tar.gz . && tar xvf special_dune.tar.gz && tar xvf ocaml-4.14.0.tar.gz && cd ocaml-4.14.0 && ./configure \"--prefix=${TMPDIR:-/tmp}/ocaml\" && make -j%{jobs}% && make install && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" %{make}% -C \"${TMPDIR:-/tmp}/dune-special_dune\" release && cp \"${TMPDIR:-/tmp}/dune-special_dune/dune.exe\" \"%{build}%/\" && cd \"%{build}%\" && autoconf && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" ./configure \"--prefix=%{prefix}%\" --enable-middle-end=flambda \"--with-dune=%{build}%/dune.exe\" && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" \"%{make}%\" -j%{jobs}% && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" \"%{make}%\" install"]
+  ["sh" "-c" "cd \"${TMPDIR:-/tmp}\" && mv \"%{build}%\"/*.tar.gz . && tar xvf special_dune.tar.gz && tar xvf ocaml-4.14.0.tar.gz && cd ocaml-4.14.0 && ./configure \"--prefix=${TMPDIR:-/tmp}/ocaml\" && make -j%{jobs}% && make install && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" %{make}% -C \"${TMPDIR:-/tmp}/dune-special_dune\" release && cp \"${TMPDIR:-/tmp}/dune-special_dune/dune.exe\" \"%{build}%/\" && cd \"%{build}%\" && autoconf && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" ./configure \"--prefix=%{prefix}%\" --enable-middle-end=flambda \"--with-dune=%{build}%/dune.exe\" --enable-legacy-library-layout && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" \"%{make}%\" -j%{jobs}% && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" \"%{make}%\" install"]
 ]
 conflicts: [
   "ocaml-option-32bit"

--- a/packages/ocaml-variants/ocaml-variants.4.14.1+flambda2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.1+flambda2/opam
@@ -20,7 +20,7 @@ setenv: [
   [OCAMLPARAM = "_,O2=1"]
 ]
 install: [
-  ["sh" "-c" "cd \"${TMPDIR:-/tmp}\" && mv \"%{build}%\"/*.tar.gz . && tar xvf special_dune.tar.gz && tar xvf ocaml-4.14.0.tar.gz && cd ocaml-4.14.0 && ./configure \"--prefix=${TMPDIR:-/tmp}/ocaml\" && make -j%{jobs}% && make install && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" %{make}% -C \"${TMPDIR:-/tmp}/dune-special_dune\" release && cp \"${TMPDIR:-/tmp}/dune-special_dune/dune.exe\" \"%{build}%/\" && cd \"%{build}%\" && autoconf && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" ./configure \"--prefix=%{prefix}%\" --enable-middle-end=flambda2 \"--with-dune=%{build}%/dune.exe\" && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" \"%{make}%\" -j%{jobs}% && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" \"%{make}%\" install"]
+  ["sh" "-c" "cd \"${TMPDIR:-/tmp}\" && mv \"%{build}%\"/*.tar.gz . && tar xvf special_dune.tar.gz && tar xvf ocaml-4.14.0.tar.gz && cd ocaml-4.14.0 && ./configure \"--prefix=${TMPDIR:-/tmp}/ocaml\" && make -j%{jobs}% && make install && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" %{make}% -C \"${TMPDIR:-/tmp}/dune-special_dune\" release && cp \"${TMPDIR:-/tmp}/dune-special_dune/dune.exe\" \"%{build}%/\" && cd \"%{build}%\" && autoconf && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" ./configure \"--prefix=%{prefix}%\" --enable-middle-end=flambda2 \"--with-dune=%{build}%/dune.exe\" --enable-legacy-library-layout && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" \"%{make}%\" -j%{jobs}% && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" \"%{make}%\" install"]
 ]
 conflicts: [
   "ocaml-option-32bit"

--- a/packages/ocaml-variants/ocaml-variants.4.14.1+pr968+flambda2/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.1+pr968+flambda2/opam
@@ -20,7 +20,7 @@ setenv: [
   [OCAMLPARAM = "_,O2=1"]
 ]
 install: [
-  ["sh" "-c" "cd \"${TMPDIR:-/tmp}\" && mv \"%{build}%\"/*.tar.gz . && tar xvf special_dune.tar.gz && tar xvf ocaml-4.14.0.tar.gz && cd ocaml-4.14.0 && ./configure \"--prefix=${TMPDIR:-/tmp}/ocaml\" && make -j%{jobs}% && make install && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" %{make}% -C \"${TMPDIR:-/tmp}/dune-special_dune\" release && cp \"${TMPDIR:-/tmp}/dune-special_dune/dune.exe\" \"%{build}%/\" && cd \"%{build}%\" && autoconf && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" ./configure \"--prefix=%{prefix}%\" --enable-middle-end=flambda2 \"--with-dune=%{build}%/dune.exe\" && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" \"%{make}%\" -j%{jobs}% && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" \"%{make}%\" install"]
+  ["sh" "-c" "cd \"${TMPDIR:-/tmp}\" && mv \"%{build}%\"/*.tar.gz . && tar xvf special_dune.tar.gz && tar xvf ocaml-4.14.0.tar.gz && cd ocaml-4.14.0 && ./configure \"--prefix=${TMPDIR:-/tmp}/ocaml\" && make -j%{jobs}% && make install && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" %{make}% -C \"${TMPDIR:-/tmp}/dune-special_dune\" release && cp \"${TMPDIR:-/tmp}/dune-special_dune/dune.exe\" \"%{build}%/\" && cd \"%{build}%\" && autoconf && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" ./configure \"--prefix=%{prefix}%\" --enable-middle-end=flambda2 \"--with-dune=%{build}%/dune.exe\" --enable-legacy-library-layout && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" \"%{make}%\" -j%{jobs}% && PATH=\"${TMPDIR:-/tmp}/ocaml/bin:$PATH\" \"%{make}%\" install"]
 ]
 conflicts: [
   "ocaml-option-32bit"


### PR DESCRIPTION
A configuration option has been added to force the flambda-backend compilers to use the same library layout as upstream 4.x compilers.
This PR passes the flag so that opam packages get the layout they expect and compile properly.